### PR TITLE
ci: run tests against ruby matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,16 +5,19 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [ '2.4', '2.7' ]
     steps:
     - uses: actions/checkout@v2
     - uses: webfactory/ssh-agent@v0.4.1
       with:
           ssh-private-key: "${{ secrets.TESTS_SSH_PRIVATE_KEY }}"
 
-    - name: Set up Ruby
+    - name: Set up Ruby ${{ matrix.ruby }}
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: ${{ matrix.ruby }}
 
     - name: Set up Node.js
       uses: actions/setup-node@v1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.configureOnOpen": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "cmake.configureOnOpen": false
-}

--- a/spec/aspera-cli_spec.rb
+++ b/spec/aspera-cli_spec.rb
@@ -29,15 +29,15 @@ demo_executor=Aspera::Ssh.new(ssh_url.host,params[:user],{:password=>params[:pas
 
 #PATH_FOLDER_MAIN='/workspace/Rubytools/aspera/local/PATH_FOLDER_MAIN'
 #demo_executor=LocalExecutor.new
-
+TEST_RUN_ID=(rand 1000).to_s
 PATH_FOLDER_TINY=File.join(PATH_FOLDER_MAIN,'aspera-test-dir-tiny')
 PATH_FOLDER_DEST=File.join(PATH_FOLDER_MAIN,'Upload')
-PATH_FOLDER_NEW=File.join(PATH_FOLDER_DEST,'newfolder')
-PATH_FOLDER_RENAMED=File.join(PATH_FOLDER_DEST,'renamedfolder')
+PATH_FOLDER_NEW=File.join(PATH_FOLDER_DEST,"newfolder-#{TEST_RUN_ID}")
+PATH_FOLDER_RENAMED=File.join(PATH_FOLDER_DEST,"renamedfolder-#{TEST_RUN_ID}")
 NAME_FILE1='200KB.1'
 PATH_FILE_EXIST=File.join(PATH_FOLDER_TINY,NAME_FILE1)
-PATH_FILE_COPY=File.join(PATH_FOLDER_DEST,NAME_FILE1+'.copy1')
-PATH_FILE_RENAMED=File.join(PATH_FOLDER_DEST,NAME_FILE1+'.renamed')
+PATH_FILE_COPY=File.join(PATH_FOLDER_DEST,NAME_FILE1+".copy1-#{TEST_RUN_ID}")
+PATH_FILE_RENAMED=File.join(PATH_FOLDER_DEST,NAME_FILE1+".renamed-#{TEST_RUN_ID}")
 PAC_FILE='file:///./examples/proxy.pac'
 
 RSpec.describe Aspera::Cli::Main do


### PR DESCRIPTION
Closes #28 

This runs the tests against ruby versions 2.4.x and 2.7.x. The ticket mentions 3.0 but it wasn't working so I think it will need some investigation before we bump it.

Due to the race condition (running these tests at the same time against the same remote files), I added an id to each of these remote file operations to prevent any conflict.