### PR TITLE
ci(#80): enable code signing on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.6
+    - name: Set up Ruby 2.7
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.7.x
 
     - name: Publish to RubyGems
       if: contains(github.ref, 'refs/tags/v')
@@ -24,7 +24,11 @@ jobs:
         touch $HOME/.gem/credentials
         chmod 0600 $HOME/.gem/credentials
         printf -- "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}\n" > $HOME/.gem/credentials
+        printf -- ${PRIVATE_KEY_PEM} > ${SIGNING_KEY}
+
         gem build *.gemspec
         gem push *.gem
       env:
         RUBYGEMS_API_KEY: "${{ secrets.RUBYGEMS_API_KEY }}"
+        PRIVATE_KEY_PEM: "${{ secrets.PRIVATE_KEY_PEM }}"
+        SIGNING_KEY: $HOME/.gem/signing_key.pem


### PR DESCRIPTION
Addresses #80 

Signs the gem file with the private key generated with Laurent's email, as this is the email listed in the `.gemspec` file.

## Rundown
1. Build with Ruby 2.7 as prior versions always prompt for the PEM passphrase even when not required.
2. Add `SIGNING_KEY` environment variable as needed by the `.gemspec` and `Makefile`.
3. Added the private key to GitHub secrets and export it to the file as defined in `SIGNING_KEY` above.