### PR TITLE
update version of terminal-table to 3.0.2

### DIFF
--- a/aspera-cli.gemspec
+++ b/aspera-cli.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('ruby-progressbar', '~> 1.0')
   spec.add_runtime_dependency('rubyzip', '~> 2.0')
   spec.add_runtime_dependency('symmetric-encryption', '~> 4.6')
-  spec.add_runtime_dependency('terminal-table', '~> 1.8')
+  spec.add_runtime_dependency('terminal-table', '~> 3.0.2')
   spec.add_runtime_dependency('tty-spinner', '~> 0.9')
   spec.add_runtime_dependency('webrick', '~> 1.7')
   spec.add_runtime_dependency('websocket', '~> 1.2')


### PR DESCRIPTION
This fixes a gem version compatibility issue between `rubocop` and `unicode-display_width`. Aspera is pegged to an older version of `terminal-table` which uses this older `unicode-display_width`. This PR uses a more recent version of the `terminal-table` gem.

Output of `bundle install` which shows the compatibility issue:
```
Bundler could not find compatible versions for gem "rubocop":
  In Gemfile:
    rubocop (~> 1.59.0)

    rubocop-sequel was resolved to 0.3.4, which depends on
      rubocop (~> 1.0)
Bundler could not find compatible versions for gem "unicode-display_width":
  In Gemfile:
    rubocop (~> 1.59.0) was resolved to 1.59.0, which depends on
      unicode-display_width (< 3.0, >= 2.4.0)

    aspera-cli (~> 4.16.0) was resolved to 4.16.0, which depends on
      terminal-table (~> 1.8) was resolved to 1.8.0, which depends on
        unicode-display_width (>= 1.1.1, ~> 1.1)
```