### PR TITLE
Fix running on Windows

### DIFF
--- a/lib/aspera/environment.rb
+++ b/lib/aspera/environment.rb
@@ -123,7 +123,7 @@ module Aspera
 
       # @return true if we can display Unicode characters
       def terminal_supports_unicode?
-        @terminal_supports_unicode = terminal? && ENV.values_at('LC_ALL', 'LC_CTYPE', 'LANG').compact.first.include?('UTF-8') if @terminal_supports_unicode.nil?
+        @terminal_supports_unicode = terminal? && ENV.values_at('LC_ALL', 'LC_CTYPE', 'LANG').compact.first&.include?('UTF-8') if @terminal_supports_unicode.nil?
         return @terminal_supports_unicode
       end
     end


### PR DESCRIPTION
This fixes the following error when running on Windows (tested on 4.18 with ruby 3.3.4-1 but maybe dating back to 4.15?)
```
lib/aspera/environment.rb:127:in `terminal_supports_unicode?': undefined method `include?' for nil (NoMethodError)

        @terminal_supports_unicode = terminal? && ENV.values_at('LC_ALL', 'LC_CTYPE', 'LANG').compact.first.include?('UTF-8') if @terminal_supports_unicode.nil?
```
None of the environment variables this line is looking for is set on Windows by default so we need to test for that possibility.